### PR TITLE
Fix default values in POJO generation

### DIFF
--- a/codegen/src/main/resources/swagwire/pojo.mustache
+++ b/codegen/src/main/resources/swagwire/pojo.mustache
@@ -28,7 +28,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}} {
   private {{{datatypeWithEnum}}} {{name}}{{#required}} = {{{defaultValue}}}{{/required}}{{^required}} = null{{/required}};
   {{/isContainer}}
   {{^isContainer}}
-  private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}}{{{defaultValue}}}{{/defaultValue}};
+  private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}};
   {{/isContainer}}
 
   {{/vars}}


### PR DESCRIPTION
Previously, when a defaultValue was supplied it would be rendered next to the field name
and not assigned to it. This adds the assignment operator so that it will behave
correctly.

For example, previously we would get:
    @SerializedName("myBoolean")
    private Boolean myBooleanfalse;

Now we get the correct

    @SerializedName("myBoolean")
    private Boolean myBoolean = false;