### PR TITLE
Upgrade swagwire response ID mapping and openapi version

### DIFF
--- a/examples/plugin/gradle.properties
+++ b/examples/plugin/gradle.properties
@@ -4,7 +4,7 @@ gsonVersion=2.11.0
 wiremockVersion=3.9.1
 
 # openapi libs
-openApiVersion=7.8.0
+openApiVersion=7.12.0
 swaggerAnnotationsVersion=2.2.23
 jakartaVersion=4.0.2
 jacksonVersion=2.17.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-openApiVersion=7.8.0
+openApiVersion=7.12.0
 spockVersion=2.4-M4-groovy-4.0
 kotlinVersion=2.0.20
 wiremockVersion=3.9.1


### PR DESCRIPTION
As we upgraded wiremock to 3.9.1, we've noticed they added stricter rules for the stubbings.

This is fine most of the time but in swagwire we have a method to apply multiple responses for a scenario and since we use the same mapping builder all the responses have the same id.

In order to have uniques IDs on each response mapping, we've used random UUID  for the builder when mapping multiple responses via swagwire.

With this change, we want to upgrade openapi version as well.